### PR TITLE
Build sdist package only once in github actions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,6 +38,7 @@ jobs:
           CIBW_ARCHS: "auto64"
 
       - name: Build sdist
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./build-sdist.sh
 
       - name: List wheels


### PR DESCRIPTION
No need to generate the same sdist package for all architecture since we
can push only once on pypi
