### PR TITLE
Re-enable wheel generation for macos_x86_64

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # see https://github.com/actions/runner-images#available-images
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-13, macos-latest, ubuntu-latest]
         python-version: ['3.11']
 
     steps:


### PR DESCRIPTION
`macos-latest` now refers to macos-14 (arm64 architecture). `macos-13`
is the last version using the x86_64 architecture
