### PR TITLE
add `JudyIntSet.update()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 	{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" },
 ]
 readme = "README.md"
-version = "2.0.6"
+version = "2.0.7"
 requires-python = ">=3.10"
 classifiers = [
 	"Development Status :: 5 - Production/Stable",

--- a/src/judy/cpp/judy.cpp
+++ b/src/judy/cpp/judy.cpp
@@ -425,6 +425,53 @@ NB_MODULE(_judy_nb, m) {
         .def("by_index", &JudyIntSet::ByIndex)
         .def("ToArray", &JudyIntSet::ToNumpyArray)
 
+        .def(
+            "update",
+            [](
+                JudyIntSet& set,
+                nb::ndarray<uint8_t, nb::shape<-1>, nb::device::cpu, nb::ro> array
+            ) {
+                set.Update(std::span{array.data(), array.shape(0)});
+            }, (
+                nb::arg("array").noconvert()
+            )
+        )
+
+        .def(
+            "update",
+            [](
+                JudyIntSet& set,
+                nb::ndarray<uint16_t, nb::shape<-1>, nb::device::cpu, nb::ro> array
+            ) {
+                set.Update(std::span{array.data(), array.shape(0)});
+            }, (
+                nb::arg("array").noconvert()
+            )
+        )
+
+        .def(
+            "update",
+            [](
+                JudyIntSet& set,
+                nb::ndarray<uint32_t, nb::shape<-1>, nb::device::cpu, nb::ro> array
+            ) {
+                set.Update(std::span{array.data(), array.shape(0)});
+            }, (
+                nb::arg("array").noconvert()
+            )
+        )
+
+        .def(
+            "update", [](
+                JudyIntSet& set,
+                nb::ndarray<uint64_t, nb::shape<-1>, nb::device::cpu, nb::ro> array
+            ) {
+                set.Update(std::span{array.data(), array.shape(0)});
+            }, (
+                nb::arg("array").noconvert()
+            )
+        )
+
         .def_static("FromArray", [](
             nb::ndarray<uint8_t, nb::shape<-1>, nb::device::cpu, nb::ro> array
         ) {

--- a/src/judy/cpp/judy_int_set.h
+++ b/src/judy/cpp/judy_int_set.h
@@ -17,6 +17,9 @@ namespace nb = nanobind;
 using namespace nb::literals;
 
 
+template <typename T>
+using nd_T = nb::ndarray<nb::numpy, T, nb::c_contig, nb::shape<-1>, nb::device::cpu>;
+
 using nd_64 = nb::ndarray<nb::numpy, uint64_t, nb::c_contig, nb::shape<-1>, nb::device::cpu>;
 
 
@@ -48,13 +51,17 @@ struct JudyIntSet {
     Word_t ByIndex(Py_ssize_t index);
 
     template <typename T>
+    void Update(const std::span<T> view)
+    {
+        for (auto value : view)
+            Add(static_cast<Word_t>(value));
+    }
+
+    template <typename T>
     static JudyIntSet FromSpan(const std::span<T> view)
     {
         auto s = JudyIntSet();
-
-        for (auto value : view)
-            s.Add(static_cast<Word_t>(value));
-
+        s.Update(view);
         return std::move(s);
     }
 };

--- a/tests/test_int_set.py
+++ b/tests/test_int_set.py
@@ -1,5 +1,6 @@
 import itertools
 import random
+from typing import Any
 
 import numpy
 import pytest
@@ -7,8 +8,11 @@ import pytest
 import judy
 
 
-@pytest.mark.parametrize('shuffled_insertion', [True, False])
-def test_insert_query_clear(*, shuffled_insertion: bool) -> None:
+@pytest.mark.parametrize(
+    'shuffled_insertion, use_update, dtype',
+    list(itertools.product([False, True], [False, True], [numpy.uint16, numpy.uint32, numpy.uint64]))
+)
+def test_insert_query_clear(*, shuffled_insertion: bool, use_update: bool, dtype: Any) -> None:
     s = judy.JudyIntSet()
 
     assert len(s) == 0
@@ -19,8 +23,12 @@ def test_insert_query_clear(*, shuffled_insertion: bool) -> None:
     if shuffled_insertion:
         random.shuffle(keys)
 
-    for key in keys:
-        s.add(key)
+    if use_update:
+        np = numpy.array(keys, dtype=dtype)
+        s.update(np)
+    else:
+        for key in keys:
+            s.add(key)
 
     for i, k in enumerate(sorted(keys)):
         assert s.by_index(i) == k


### PR DESCRIPTION
It accepts all 1d numpy unsigned int arrays. For large arrays, it takes about 1/3rd the time as a naive for-loop:


```python
import time

import numpy

import judy


values = list(range(100_000_000))
values_np = numpy.array(values, dtype=numpy.uint32)

a = judy.JudyIntSet()
b = judy.JudyIntSet()

t_0 = time.monotonic()

for value in values:
    a.add(value)

t_1 = time.monotonic()

b.update(values_np)

t_2 = time.monotonic()

print(t_1 - t_0)
print(t_2 - t_1)
```
 